### PR TITLE
Add additional templating for NiFi configuration files

### DIFF
--- a/configs/bootstrap.conf
+++ b/configs/bootstrap.conf
@@ -32,8 +32,8 @@ graceful.shutdown.seconds=20
 java.arg.1=-Dorg.apache.jasper.compiler.disablejsr199=true
 
 # JVM memory settings
-java.arg.2=-Xms{{.Values.jvmMemory}}
-java.arg.3=-Xmx{{.Values.jvmMemory}}
+java.arg.2=-Xms{{.Values.jvmMemoryArg2}}
+java.arg.3=-Xmx{{.Values.jvmMemoryArg3}}
 
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -31,7 +31,7 @@ nifi.authorizer.configuration.file=./conf/authorizers.xml
 nifi.login.identity.provider.configuration.file=./conf/login-identity-providers.xml
 nifi.templates.directory=../data/templates
 nifi.ui.banner.text=
-nifi.ui.autorefresh.interval=30 sec
+nifi.ui.autorefresh.interval={{.Values.properties.uiAutorefreshInterval}}
 nifi.nar.library.directory=./lib
 nifi.nar.library.directory.custom={{.Values.properties.customLibPath}}
 nifi.nar.library.autoload.directory=./extensions
@@ -53,18 +53,18 @@ nifi.state.management.embedded.zookeeper.properties=./conf/zookeeper.properties
 
 
 # H2 Settings
-nifi.database.directory=../data/database_repository
+nifi.database.directory={{.Values.properties.databaseDirectory}}
 nifi.h2.url.append=;LOCK_TIMEOUT=25000;WRITE_DELAY=0;AUTO_SERVER=FALSE
 
 # FlowFile Repository
 nifi.flowfile.repository.implementation=org.apache.nifi.controller.repository.WriteAheadFlowFileRepository
-nifi.flowfile.repository.directory=../flowfile_repository
+nifi.flowfile.repository.directory={{.Values.properties.flowfileRepositoryDirectory}}
 nifi.flowfile.repository.partitions=256
 nifi.flowfile.repository.checkpoint.interval=2 mins
 nifi.flowfile.repository.always.sync=false
 
 nifi.swap.manager.implementation=org.apache.nifi.controller.FileSystemSwapManager
-nifi.queue.swap.threshold=20000
+nifi.queue.swap.threshold={{.Values.properties.queueSwapThreshold}}
 nifi.swap.in.period=5 sec
 nifi.swap.in.threads=1
 nifi.swap.out.period=5 sec
@@ -74,7 +74,7 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
-nifi.content.repository.directory.default=../content_repository
+nifi.content.repository.directory.default={{.Values.properties.contentRepoDirDefault}}
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%
 nifi.content.repository.archive.enabled=true

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -74,10 +74,8 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
-# nifi.content.repository.directory.default={{.Values.properties.contentRepoDirDefault}}
-{{- range $key, $value := .Values.properties.contentDirectories }}
-{{$key}}={{$value}}
-{{- end }}
+nifi.content.repository.directory.default={{.Values.properties.contentRepoDirDefault}}
+
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%
 nifi.content.repository.archive.enabled=true

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -74,7 +74,7 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
-nifi.content.repository.directory.default={{.Values.properties.contentRepoDirDefault}}
+# nifi.content.repository.directory.default={{.Values.properties.contentRepoDirDefault}}
 {{- range $key, $value := .Values.properties.contentDirectories }}
 {{$key}}={{$value}}
 {{- end }}

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -90,7 +90,7 @@ nifi.provenance.repository.encryption.key.id=
 nifi.provenance.repository.encryption.key=
 
 # Persistent Provenance Repository Properties
-nifi.provenance.repository.directory.default=../provenance_repository
+nifi.provenance.repository.directory.default={{.Values.properties.provenanceDirectoryDefault}}
 nifi.provenance.repository.max.storage.time={{.Values.properties.provenanceMaxStorageTime}}
 nifi.provenance.repository.max.storage.size={{.Values.properties.provenanceStorage}}
 nifi.provenance.repository.rollover.time=30 secs

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -74,9 +74,12 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
+{{- if .Values.contentDirectoryDefault }}
 nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
+{{- else }}
 {{- range $key, $value := .Values.properties.contentDirectories }}
 {{$key}}={{$value}}
+{{- end }}
 {{- end }}
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -77,9 +77,9 @@ nifi.content.claim.max.flow.files=100
 {{- if .Values.properties.contentDirectoryDefault }}
 nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
 {{- else }}
-{{- range $key, $value := .Values.properties.contentDirectories }}
-{{$key}}={{$value}}
-{{- end }}
+  {{- range $key, $value := .Values.properties.contentDirectories }}
+    {{$key}}={{$value}}
+  {{- end }}
 {{- end }}
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -74,7 +74,7 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
-{{- if .Values.contentDirectoryDefault }}
+{{- if .Values.properties.contentDirectoryDefault }}
 nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
 {{- else }}
 {{- range $key, $value := .Values.properties.contentDirectories }}

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -75,6 +75,9 @@ nifi.content.repository.implementation=org.apache.nifi.controller.repository.Fil
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
 nifi.content.repository.directory.default={{.Values.properties.contentRepoDirDefault}}
+{{- range $key, $value := .Values.properties.contentDirectories }}
+{{$key}}={{$value}}
+{{- end }}
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%
 nifi.content.repository.archive.enabled=true

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -64,7 +64,7 @@ nifi.flowfile.repository.checkpoint.interval=2 mins
 nifi.flowfile.repository.always.sync=false
 
 nifi.swap.manager.implementation=org.apache.nifi.controller.FileSystemSwapManager
-nifi.queue.swap.threshold={{.Values.properties.queueSwapThreshold}}
+nifi.queue.swap.threshold=8000#{{.Values.properties.queueSwapThreshold}}
 nifi.swap.in.period=5 sec
 nifi.swap.in.threads=1
 nifi.swap.out.period=5 sec

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -74,12 +74,12 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
-{{- if .Values.properties.contentDirectoryDefault}}
-nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
-{{- else}}
+{{- if .Values.properties.contentDirectories}}
   {{- range $key, $value := .Values.properties.contentDirectories}}
 {{$key}}={{$value}}
   {{- end}}
+{{- else}}
+nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
 {{- end}}
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -64,7 +64,7 @@ nifi.flowfile.repository.checkpoint.interval=2 mins
 nifi.flowfile.repository.always.sync=false
 
 nifi.swap.manager.implementation=org.apache.nifi.controller.FileSystemSwapManager
-nifi.queue.swap.threshold=8000#{{.Values.properties.queueSwapThreshold}}
+nifi.queue.swap.threshold={{.Values.properties.queueSwapThreshold}}
 nifi.swap.in.period=5 sec
 nifi.swap.in.threads=1
 nifi.swap.out.period=5 sec

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -74,13 +74,13 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
-{{- if .Values.properties.contentDirectoryDefault }}
+{{- if .Values.properties.contentDirectoryDefault}}
 nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
-{{- else }}
-  {{- range $key, $value := .Values.properties.contentDirectories }}
+{{- else}}
+  {{- range $key, $value := .Values.properties.contentDirectories}}
 {{$key}}={{$value}}
-  {{- end }}
-{{- end }}
+  {{- end}}
+{{- end}}
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%
 nifi.content.repository.archive.enabled=true

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -25,7 +25,7 @@ nifi.flowcontroller.graceful.shutdown.period=10 sec
 nifi.flowservice.writedelay.interval=500 ms
 nifi.administrative.yield.duration=30 sec
 # If a component has no work to do (is "bored"), how long should we wait before checking again for work?
-nifi.bored.yield.duration=10 millis
+nifi.bored.yield.duration={{.Values.properties.boredYieldDuration}}
 
 nifi.authorizer.configuration.file=./conf/authorizers.xml
 nifi.login.identity.provider.configuration.file=./conf/login-identity-providers.xml

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -74,8 +74,10 @@ nifi.swap.out.threads=4
 nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
 nifi.content.claim.max.appendable.size=1 MB
 nifi.content.claim.max.flow.files=100
-nifi.content.repository.directory.default={{.Values.properties.contentRepoDirDefault}}
-
+nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
+{{- range $key, $value := .Values.properties.contentDirectories }}
+{{$key}}={{$value}}
+{{- end }}
 nifi.content.repository.archive.max.retention.period=3 days
 nifi.content.repository.archive.max.usage.percentage=85%
 nifi.content.repository.archive.enabled=true

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -78,7 +78,7 @@ nifi.content.claim.max.flow.files=100
 nifi.content.repository.directory.default={{.Values.properties.contentDirectoryDefault}}
 {{- else }}
   {{- range $key, $value := .Values.properties.contentDirectories }}
-    {{$key}}={{$value}}
+{{$key}}={{$value}}
   {{- end }}
 {{- end }}
 nifi.content.repository.archive.max.retention.period=3 days

--- a/values.yaml
+++ b/values.yaml
@@ -98,12 +98,14 @@ properties:
   uiAutorefreshInterval: "30 sec"
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
-  queueSwapThreshold: 5000
-  # contentDirectoryDefault: "../content_repository"
-  contentDirectories:
-    "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"
-    "nifi.content.repository.directory.contS1R2": "../cont-repo2/content_repository"
-    "nifi.content.repository.directory.contS1R3": "../cont-repo3/content_repository"
+  queueSwapThreshold: 20000
+  contentDirectoryDefault: "../content_repository"
+  # Comment out above contentDirectoryDefault to configure multiple content repositories within a single instance of NiFi
+  ## Multiple content repositories:
+  # contentDirectories:
+  #   "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"
+  #   "nifi.content.repository.directory.contS1R2": "../cont-repo2/content_repository"
+  #   "nifi.content.repository.directory.contS1R3": "../cont-repo3/content_repository"
   provenanceDirectoryDefault: "../provenance_repository"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"

--- a/values.yaml
+++ b/values.yaml
@@ -95,6 +95,11 @@ properties:
   webProxyHost: # <clusterIP>:<NodePort> (If Nifi service is NodePort or LoadBalancer)
   clusterPort: 6007
   boredYieldDuration: "10 millis"
+  uiAutorefreshInterval: "30 sec"
+  databaseDirectory: "../data/database_repository"
+  flowfileRepositoryDirectory: "../flowfile_repository"
+  queueSwapThreshold: 20000
+  contentRepoDirDefault: "../content_repository"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"
   siteToSite:

--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,9 @@ properties:
   flowfileRepositoryDirectory: "../flowfile_repository"
   queueSwapThreshold: 20000
   contentRepoDirDefault: "../content_repository"
+  contentDirectories:
+    - "blahkey_1": "blahvalue_1"
+    - "blahkey_2": "blahvalue_2"
   provenanceDirectoryDefault: "../provenance_repository"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"

--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,7 @@ properties:
   flowfileRepositoryDirectory: "../flowfile_repository"
   queueSwapThreshold: 20000
   contentRepoDirDefault: "../content_repository"
+  provenanceDirectoryDefault: "../provenance_repository"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"
   siteToSite:

--- a/values.yaml
+++ b/values.yaml
@@ -99,9 +99,8 @@ properties:
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
   queueSwapThreshold: 20000
-  # Comment out below contentDirectoryDefault to configure multiple content repositories within a single instance of NiFi
   contentDirectoryDefault: "../content_repository"
-  ## Multiple content repositories:
+  ## Configure multiple content repositories within a single instance of NiFi:
   # contentDirectories:
   #   "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"
   #   "nifi.content.repository.directory.contS1R2": "../cont-repo2/content_repository"

--- a/values.yaml
+++ b/values.yaml
@@ -94,7 +94,7 @@ properties:
   httpsPort: 8443
   webProxyHost: # <clusterIP>:<NodePort> (If Nifi service is NodePort or LoadBalancer)
   clusterPort: 6007
-  boredYieldDuration: 10 millis
+  boredYieldDuration: "10 millis"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"
   siteToSite:

--- a/values.yaml
+++ b/values.yaml
@@ -98,7 +98,7 @@ properties:
   uiAutorefreshInterval: "30 sec"
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
-  queueSwapThreshold: "15000"
+  queueSwapThreshold: "5000"
   # contentDirectoryDefault: "../content_repository"
   contentDirectories:
     "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"

--- a/values.yaml
+++ b/values.yaml
@@ -119,7 +119,7 @@ auth:
   SSL:
     keystorePasswd: changeMe
     truststorePasswd: changeMe
-
+ 
   # Automaticaly disabled if OIDC or LDAP enabled
   singleUser:
     username: username

--- a/values.yaml
+++ b/values.yaml
@@ -99,7 +99,7 @@ properties:
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
   queueSwapThreshold: 20000
-  contentRepoDirDefault: "../content_repository"
+  contentDirectoryDefault: "../content_repository"
   contentDirectories:
     "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"
     "nifi.content.repository.directory.contS1R2": "../cont-repo2/content_repository"

--- a/values.yaml
+++ b/values.yaml
@@ -98,7 +98,7 @@ properties:
   uiAutorefreshInterval: "30 sec"
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
-  queueSwapThreshold: "5000"
+  queueSwapThreshold: 5000
   # contentDirectoryDefault: "../content_repository"
   contentDirectories:
     "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"

--- a/values.yaml
+++ b/values.yaml
@@ -94,6 +94,7 @@ properties:
   httpsPort: 8443
   webProxyHost: # <clusterIP>:<NodePort> (If Nifi service is NodePort or LoadBalancer)
   clusterPort: 6007
+  boredYieldDuration: 10 millis
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"
   siteToSite:

--- a/values.yaml
+++ b/values.yaml
@@ -103,6 +103,7 @@ properties:
   contentDirectories:
     "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"
     "nifi.content.repository.directory.contS1R2": "../cont-repo2/content_repository"
+    "nifi.content.repository.directory.contS1R3": "../cont-repo3/content_repository"
   provenanceDirectoryDefault: "../provenance_repository"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"

--- a/values.yaml
+++ b/values.yaml
@@ -131,7 +131,7 @@ auth:
   SSL:
     keystorePasswd: changeMe
     truststorePasswd: changeMe
- 
+
   # Automaticaly disabled if OIDC or LDAP enabled
   singleUser:
     username: username
@@ -221,11 +221,11 @@ service:
         port: 7002
         targetPort: 7002
         #nodePort: 30702
-## Configure containerPorts section with following attributes: name, containerport and protocol. 
+## Configure containerPorts section with following attributes: name, containerport and protocol.
 containerPorts: []
 # - name: example
 #   containerPort: 1111
-#   protocol: TCP 
+#   protocol: TCP
 
 ## Configure Ingress based on the documentation here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##
@@ -239,7 +239,8 @@ ingress:
   # If you want to change the default path, see this issue https://github.com/cetic/helm-nifi/issues/22
 
 # Amount of memory to give the NiFi java heap
-jvmMemory: 2g
+jvmMemoryArg2: 2g
+jvmMemoryArg3: 2g
 
 # Separate image for tailing each log separately and checking zookeeper connectivity
 sidecar:

--- a/values.yaml
+++ b/values.yaml
@@ -99,7 +99,7 @@ properties:
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
   queueSwapThreshold: 20000
-  contentDirectoryDefault: "../content_repository"
+  # contentDirectoryDefault: "../content_repository"
   contentDirectories:
     "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"
     "nifi.content.repository.directory.contS1R2": "../cont-repo2/content_repository"

--- a/values.yaml
+++ b/values.yaml
@@ -98,7 +98,7 @@ properties:
   uiAutorefreshInterval: "30 sec"
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
-  queueSwapThreshold: 15000
+  queueSwapThreshold: "15000"
   # contentDirectoryDefault: "../content_repository"
   contentDirectories:
     "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"

--- a/values.yaml
+++ b/values.yaml
@@ -98,7 +98,7 @@ properties:
   uiAutorefreshInterval: "30 sec"
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
-  queueSwapThreshold: 20000
+  queueSwapThreshold: 15000
   # contentDirectoryDefault: "../content_repository"
   contentDirectories:
     "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"

--- a/values.yaml
+++ b/values.yaml
@@ -101,8 +101,8 @@ properties:
   queueSwapThreshold: 20000
   contentRepoDirDefault: "../content_repository"
   contentDirectories:
-    "blahkey_1": "blahvalue_1"
-    "blahkey_2": "blahvalue_2"
+    "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"
+    "nifi.content.repository.directory.contS1R2": "../cont-repo2/content_repository"
   provenanceDirectoryDefault: "../provenance_repository"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"

--- a/values.yaml
+++ b/values.yaml
@@ -101,8 +101,8 @@ properties:
   queueSwapThreshold: 20000
   contentRepoDirDefault: "../content_repository"
   contentDirectories:
-    - "blahkey_1": "blahvalue_1"
-    - "blahkey_2": "blahvalue_2"
+    "blahkey_1": "blahvalue_1"
+    "blahkey_2": "blahvalue_2"
   provenanceDirectoryDefault: "../provenance_repository"
   provenanceStorage: "8 GB"
   provenanceMaxStorageTime: "10 days"

--- a/values.yaml
+++ b/values.yaml
@@ -99,8 +99,8 @@ properties:
   databaseDirectory: "../data/database_repository"
   flowfileRepositoryDirectory: "../flowfile_repository"
   queueSwapThreshold: 20000
+  # Comment out below contentDirectoryDefault to configure multiple content repositories within a single instance of NiFi
   contentDirectoryDefault: "../content_repository"
-  # Comment out above contentDirectoryDefault to configure multiple content repositories within a single instance of NiFi
   ## Multiple content repositories:
   # contentDirectories:
   #   "nifi.content.repository.directory.contS1R1": "../cont-repo1/content_repository"


### PR DESCRIPTION
Additional templating in nifi.properties for:
- nifi.bored.yield.duration
- nifi.ui.autorefresh.interval
- nifi.database.directory
- nifi.flowfile.repository.directory
- nifi.queue.swap.threshold
- nifi.provenance.repository.directory.default
- configurable multiple content repositories within a single instance

In bootstrap.conf:
- Make java.arg.2 and java.arg.3 JVM memory individually configurable 

Tests:
<pre>                       Original                                                      New</pre>

![image](https://github.com/jjw24/helm-nifi/assets/26427004/35844e7e-4b9b-4198-9a51-a2dd7e963378)

![image](https://github.com/jjw24/helm-nifi/assets/26427004/0ce36c50-1d21-4a7c-9fd4-1e8219902fff)

bootstrap.conf's JVM memory configured separately:
![image](https://github.com/jjw24/helm-nifi/assets/26427004/d4fd7b2e-6e5c-4c3f-94c2-f6c819e2d668)
